### PR TITLE
Unknown option: storeURL (bug 1045716)

### DIFF
--- a/receiptverifier-ui.js
+++ b/receiptverifier-ui.js
@@ -85,7 +85,7 @@ var $ = (function(win, doc, undefined) {
 
 function Prompter(options) {
   var i;
-  if (! this instanceof Prompter) {
+  if (! (this instanceof Prompter)) {
     return new Prompter(options);
   }
   options = options || {};

--- a/test-ui.html
+++ b/test-ui.html
@@ -28,7 +28,7 @@ function runTest(state, error, options) {
   if (error) {
     verifier.receiptErrors['test'] = error;
   }
-  var ui = new mozmarket.receipts.Prompter(options);
+  var ui = mozmarket.receipts.Prompter(options);
   ui.respond(verifier);
 }
 


### PR DESCRIPTION
Original problem description is:

With the latest code and with an HTML page that runs this: 

```
mozmarket.receipts.Prompter({
    storeURL: "https://marketplace.mozilla.org/app/myapp",
    supportHTML: '<a href="mailto:me@example.com">email me@example.com</a>',
    verify: true
});
```

I get this error: Unknown option: storeURL. 

After experimenting I find that:

```
mozmarket.receipts.Prompter({
    storeURL: "https://marketplace.mozilla.org/app/myapp",
    supportHTML: '<a href="mailto:me@example.com">email me@example.com</a>',
    verify: false
});

"Unknown option: storeURL"

new mozmarket.receipts.Prompter({
    storeURL: "https://marketplace.mozilla.org/app/myapp",
    supportHTML: '<a href="mailto:me@example.com">email me@example.com</a>',
    verify: false
});

Prompter {overlay: null, storeURL: "https://marketplace.mozilla.org/app/myapp", supportHTML: "<a href="mailto:me@example.com">email me@example.com</a>", allowNoInstall: false, ignoreInternalError: false…}
```

There is a line designed to catch this here: https://github.com/mozilla/receiptverifier/blob/master/receiptverifier-ui.js#L88-L90

However I think that the test was malformed, example:

```
this instanceof Prompter
false

! this instanceof Prompter
false

! (this instanceof Prompter)
true
```

I think this should solve the problem.  Example:

```
mozmarket.receipts.Prompter({
    storeURL: "https://marketplace.mozilla.org/app/myapp",
    supportHTML: '<a href="mailto:me@example.com">email me@example.com</a>',
    verify: false
});

Prompter {overlay: null, storeURL: "https://marketplace.mozilla.org/app/myapp", supportHTML: "<a href="mailto:me@example.com">email me@example.com</a>", allowNoInstall: false, ignoreInternalError: false…}
```
